### PR TITLE
added Confidence Score Visualization

### DIFF
--- a/frontend/components/AnalysisResult.tsx
+++ b/frontend/components/AnalysisResult.tsx
@@ -3,8 +3,11 @@
 import React from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
 import { AnalysisResult as AnalysisResultType } from '@/utils/api'
-import { CheckCircle2, XCircle } from 'lucide-react'
+import { CheckCircle2, XCircle, AlertTriangle, XOctagon } from 'lucide-react'
 import { Button } from './ui/button'
+import { ProgressBar } from './ui/ProgressBar'
+import { Badge } from './ui/Badge'
+import { Tooltip } from './ui/tooltip'
 
 interface AnalysisResultProps {
   result: AnalysisResultType
@@ -12,24 +15,57 @@ interface AnalysisResultProps {
 }
 
 export const AnalysisResult: React.FC<AnalysisResultProps> = ({ result, onClose }) => {
+  // Calculate confidence details
+  const confidencePercent = Math.round(result.confidence * 100)
+  let confidenceLevel: 'high' | 'moderate' | 'low'
+  let color: 'green' | 'yellow' | 'red'
+  let icon = null
+  let explanation = ''
+  if (confidencePercent >= 80) {
+    confidenceLevel = 'high'
+    color = 'green'
+    icon = <CheckCircle2 className="h-5 w-5 text-green-600" aria-label="High confidence" />
+    explanation = "We're very confident about this diagnosis"
+  } else if (confidencePercent >= 50) {
+    confidenceLevel = 'moderate'
+    color = 'yellow'
+    icon = <AlertTriangle className="h-5 w-5 text-yellow-500" aria-label="Moderate confidence" />
+    explanation = "This diagnosis is likely, but consider getting a second opinion"
+  } else {
+    confidenceLevel = 'low'
+    color = 'red'
+    icon = <XOctagon className="h-5 w-5 text-red-600" aria-label="Low confidence" />
+    explanation = "Uncertain diagnosis. We recommend consulting an expert"
+  }
+
   return (
     <Card className="w-full border-primary border-2">
       <CardHeader>
         <div className="flex justify-between items-start">
           <div>
             <CardTitle className="text-primary mb-2">Analysis Complete</CardTitle>
-            <p className="text-sm text-gray-600">
-              Confidence: <strong>{(result.confidence * 100).toFixed(1)}%</strong>
-            </p>
+            <Tooltip content="Confidence indicates how certain the AI is about this diagnosis">
+              <div className="flex items-center gap-2 mt-1" tabIndex={0} aria-label={`Confidence: ${confidencePercent}% (${confidenceLevel})`}>
+                <Badge color={color} className="text-base px-3 py-1">
+                  {icon}
+                  <span className="ml-1 font-semibold capitalize">{confidenceLevel}</span>
+                </Badge>
+                <span className="text-gray-700 font-medium text-base">{confidencePercent}%</span>
+              </div>
+            </Tooltip>
+            <div className="mt-2" aria-label={`Confidence progress bar: ${confidencePercent}%`}>
+              <ProgressBar value={confidencePercent} color={color} label="Confidence" />
+            </div>
+            <div className="mt-2 text-sm text-gray-700" aria-live="polite">{explanation}</div>
           </div>
-          <Button variant="ghost" size="icon" onClick={onClose}>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close analysis result">
             <XCircle className="h-5 w-5" />
           </Button>
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex items-center gap-3 p-4 bg-primary/10 rounded-lg">
-          <CheckCircle2 className="h-6 w-6 text-primary" />
+          <span aria-hidden="true">{icon}</span>
           <div>
             <h3 className="font-semibold text-gray-800 text-lg">{result.disease}</h3>
           </div>

--- a/frontend/components/ScanHistoryCard.tsx
+++ b/frontend/components/ScanHistoryCard.tsx
@@ -2,9 +2,12 @@
 
 import React, { useEffect, useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
-import { Leaf, Trash2 } from 'lucide-react'
+import { Leaf, Trash2, CheckCircle2, AlertTriangle, XOctagon } from 'lucide-react'
 import { getHistory, deleteHistoryItem, AnalysisResult, API_URL } from '@/utils/api'
 import { Button } from './ui/button'
+import { ProgressBar } from './ui/ProgressBar'
+import { Badge } from './ui/Badge'
+import { Tooltip } from './ui/tooltip'
 import Image from 'next/image'
 
 export const ScanHistoryCard: React.FC = () => {
@@ -82,9 +85,62 @@ export const ScanHistoryCard: React.FC = () => {
                     <div className="flex justify-between items-start mb-2">
                       <div>
                         <h3 className="font-semibold text-gray-800">{item.disease}</h3>
-                        <p className="text-sm text-gray-500">
-                          Confidence: {(item.confidence * 100).toFixed(1)}%
-                        </p>
+                        {(() => {
+                          const confidencePercent = Math.round(item.confidence * 100)
+                          let confidenceLevel: 'high' | 'moderate' | 'low'
+                          let color: 'green' | 'yellow' | 'red'
+                          let icon = null
+                          let explanation = ''
+                          if (confidencePercent >= 80) {
+                            confidenceLevel = 'high'
+                            color = 'green'
+                            icon = <CheckCircle2 className="h-4 w-4 text-green-600" aria-label="High confidence" />
+                            explanation = "We're very confident about this diagnosis"
+                          } else if (confidencePercent >= 50) {
+                            confidenceLevel = 'moderate'
+                            color = 'yellow'
+                            icon = <AlertTriangle className="h-4 w-4 text-yellow-500" aria-label="Moderate confidence" />
+                            explanation = "This diagnosis is likely, but consider getting a second opinion"
+                          } else {
+                            confidenceLevel = 'low'
+                            color = 'red'
+                            icon = <XOctagon className="h-4 w-4 text-red-600" aria-label="Low confidence" />
+                            explanation = "Uncertain diagnosis. We recommend consulting an expert"
+                          }
+                          return (
+                            <Tooltip content="Confidence indicates how certain the AI is about this diagnosis">
+                              <div className="flex items-center gap-2 mt-1" tabIndex={0} aria-label={`Confidence: ${confidencePercent}% (${confidenceLevel})`}>
+                                <Badge color={color} className="text-xs px-2 py-0.5">
+                                  {icon}
+                                  <span className="ml-1 font-semibold capitalize">{confidenceLevel}</span>
+                                </Badge>
+                                <span className="text-gray-700 font-medium text-xs">{confidencePercent}%</span>
+                              </div>
+                            </Tooltip>
+                          )
+                        })()}
+                        {(() => {
+                          const confidencePercent = Math.round(item.confidence * 100)
+                          let color: 'green' | 'yellow' | 'red'
+                          if (confidencePercent >= 80) color = 'green'
+                          else if (confidencePercent >= 50) color = 'yellow'
+                          else color = 'red'
+                          return (
+                            <div className="mt-1" aria-label={`Confidence progress bar: ${confidencePercent}%`}>
+                              <ProgressBar value={confidencePercent} color={color} />
+                            </div>
+                          )
+                        })()}
+                        {(() => {
+                          const confidencePercent = Math.round(item.confidence * 100)
+                          let explanation = ''
+                          if (confidencePercent >= 80) explanation = "We're very confident about this diagnosis"
+                          else if (confidencePercent >= 50) explanation = "This diagnosis is likely, but consider getting a second opinion"
+                          else explanation = "Uncertain diagnosis. We recommend consulting an expert"
+                          return (
+                            <div className="mt-1 text-xs text-gray-700" aria-live="polite">{explanation}</div>
+                          )
+                        })()}
                       </div>
                       <Button
                         variant="ghost"

--- a/frontend/components/ui/Badge.tsx
+++ b/frontend/components/ui/Badge.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  color: "green" | "yellow" | "red";
+  children: React.ReactNode;
+}
+
+export const Badge: React.FC<BadgeProps> = ({ color, children, className, ...props }) => {
+  const colorClass =
+    color === "green"
+      ? "bg-green-100 text-green-800 border-green-400"
+      : color === "yellow"
+      ? "bg-yellow-100 text-yellow-800 border-yellow-400"
+      : "bg-red-100 text-red-800 border-red-400";
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2.5 py-0.5 rounded-full border text-xs font-semibold mr-2",
+        colorClass,
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+};

--- a/frontend/components/ui/ProgressBar.tsx
+++ b/frontend/components/ui/ProgressBar.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+
+export interface ProgressBarProps {
+  value: number; // 0-100
+  color: "green" | "yellow" | "red";
+  label?: string;
+}
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({ value, color, label }) => {
+  const barColor =
+    color === "green"
+      ? "bg-green-500"
+      : color === "yellow"
+      ? "bg-yellow-400"
+      : "bg-red-500";
+  return (
+    <div className="w-full">
+      {label && <div className="mb-1 text-sm font-medium text-gray-700">{label}</div>}
+      <div className="w-full bg-gray-200 rounded-full h-4" role="progressbar" aria-valuenow={value} aria-valuemin={0} aria-valuemax={100}>
+        <div
+          className={`h-4 rounded-full transition-all duration-500 ease-in-out ${barColor}`}
+          style={{ width: `${value}%` }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+export interface TooltipProps {
+  content: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({ content, children }) => {
+  const [visible, setVisible] = React.useState(false);
+  return (
+    <span className="relative inline-block">
+      <span
+        onMouseEnter={() => setVisible(true)}
+        onFocus={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onBlur={() => setVisible(false)}
+        tabIndex={0}
+        aria-describedby="confidence-tooltip"
+        className="outline-none"
+      >
+        {children}
+      </span>
+      {visible && (
+        <span
+          id="confidence-tooltip"
+          role="tooltip"
+          className="absolute z-10 left-1/2 -translate-x-1/2 mt-2 px-3 py-2 text-xs text-white bg-gray-900 rounded shadow-lg whitespace-nowrap"
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  );
+};


### PR DESCRIPTION
Fixes #22 

1.Added color-coded confidence badges (🟢/🟡/🔴) for high, moderate, and low confidence.
2.Integrated a progress bar to visually represent the confidence percentage.
3.Included contextual icons (✔️, ⚠️, ❌) for each confidence level.
4.Displayed explanatory text for each confidence range.
5.Added a tooltip explaining what the confidence score means.
<img width="676" height="153" alt="Screenshot 2025-11-12 234312" src="https://github.com/user-attachments/assets/6c3d8654-5f1c-4428-a928-c6de7cc652dd" />
<img width="676" height="143" alt="Screenshot 2025-11-12 234326" src="https://github.com/user-attachments/assets/c9300d81-d963-4fb8-bf33-aaf060142493" />
<img width="694" height="160" alt="Screenshot 2025-11-12 234341" src="https://github.com/user-attachments/assets/4e284176-9d58-47d5-ba8e-8d4046398ea6" />
